### PR TITLE
Resolves issues caused by converting the base image to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@ FROM openjdk:8u131-jre-alpine
 VOLUME ["/server", "/plugins"]
 WORKDIR /server
 
+ENV BUNGEE_HOME=/server \
+    BUNGEE_BASE_URL=https://ci.md-5.net/job/BungeeCord \
+    MEMORY=512m \
+    UID=1000 \
+    GID=1000
+
 COPY *.sh /usr/bin/
 
 RUN apk --no-cache add curl
@@ -10,11 +16,10 @@ RUN apk --no-cache add bash
 
 EXPOSE 25577
 
-ENV BUNGEE_HOME=/server \
-    BUNGEE_BASE_URL=https://ci.md-5.net/job/BungeeCord \
-    MEMORY=512m \
-    UID=1000 \
-    GID=1000
+RUN set -x \
+	&& addgroup -g 1000 -S bungeecord \
+	&& adduser -u 1000 -D -S -G bungeecord bungeecord
 
-#ENTRYPOINT ["/usr/bin/run-bungeecord.sh"]
-ENTRYPOINT ["/bin/bash"]
+USER bungeecord
+
+ENTRYPOINT ["/usr/bin/run-bungeecord.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,16 @@ WORKDIR /server
 
 COPY *.sh /usr/bin/
 
+RUN apk --no-cache add curl
+RUN apk --no-cache add bash
+
 EXPOSE 25577
 
 ENV BUNGEE_HOME=/server \
     BUNGEE_BASE_URL=https://ci.md-5.net/job/BungeeCord \
-    MEMORY=512m
+    MEMORY=512m \
+    UID=1000 \
+    GID=1000
 
-ENTRYPOINT ["/usr/bin/run-bungeecord.sh"]
+#ENTRYPOINT ["/usr/bin/run-bungeecord.sh"]
+ENTRYPOINT ["/bin/bash"]

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -18,25 +18,4 @@ fi
 echo "Setting initial memory to ${INIT_MEMORY:-${MEMORY}} and max to ${MAX_MEMORY:-${MEMORY}}"
 JVM_OPTS="-Xms${INIT_MEMORY:-${MEMORY}} -Xmx${MAX_MEMORY:-${MEMORY}} ${JVM_OPTS}"
 
-if [[ -n "$UID" ]]; then
-    #    -h DIR          Home directory
-    #    -G GRP          Add user to existing group
-    #    -S              Create a system user
-    #    -D              Don't assign a password
-    #    -H              Don't create home directory
-    #    -u UID          User id
-    #    -k SKEL         Skeleton directory (/etc/skel)
-    userAddArgs="-D -S -H -u $UID"
-
-    if [[ -n "$GID" ]]; then
-        userAddArgs="$userAddArgs -g $GID"
-        addgroup -g ${GID} bungeecord
-    fi
-
-    adduser -h ${BUNGEE_HOME} ${userAddArgs} bungeecord
-
-    chown -R bungeecord: ${BUNGEE_HOME}
-    sudo -u bungeecord java -- ${JVM_OPTS} -jar $BUNGEE_JAR "$@"
-else
-    exec java $JVM_OPTS -jar $BUNGEE_JAR "$@"
-fi
+exec java $JVM_OPTS -jar $BUNGEE_JAR "$@"

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -3,34 +3,40 @@
 BUNGEE_JAR=$BUNGEE_HOME/BungeeCord.jar
 
 if [[ ! -e $BUNGEE_JAR ]]; then
-  echo "Downloading ${BUNGEE_JAR_URL:=${BUNGEE_BASE_URL}/${BUNGEE_JOB_ID:-lastStableBuild}/artifact/bootstrap/target/BungeeCord.jar}"
-  if ! curl -o $BUNGEE_JAR -fsSL $BUNGEE_JAR_URL; then
-    echo "ERROR: failed to download" >&2
-    exit 2
-  fi
+    echo "Downloading ${BUNGEE_JAR_URL:=${BUNGEE_BASE_URL}/${BUNGEE_JOB_ID:-lastStableBuild}/artifact/bootstrap/target/BungeeCord.jar}"
+    if ! curl -o $BUNGEE_JAR -fsSL $BUNGEE_JAR_URL; then
+        echo "ERROR: failed to download" >&2
+        exit 2
+    fi
 fi
 
 if [ -d /plugins ]; then
-  echo "Copying BungeeCord plugins over..."
-  cp -r /plugins $BUNGEE_HOME
+    echo "Copying BungeeCord plugins over..."
+    cp -r /plugins $BUNGEE_HOME
 fi
   
 echo "Setting initial memory to ${INIT_MEMORY:-${MEMORY}} and max to ${MAX_MEMORY:-${MEMORY}}"
 JVM_OPTS="-Xms${INIT_MEMORY:-${MEMORY}} -Xmx${MAX_MEMORY:-${MEMORY}} ${JVM_OPTS}"
 
-userAddArgs=
-if [[ -n $UID ]]; then
-  userAddArgs="$userAddArgs --uid $UID"
-fi
-if [[ -n $GID ]]; then
-  userAddArgs="$userAddArgs --gid $GID"
-  groupadd --gid $GID bungeecord
-fi
+if [[ -n "$UID" ]]; then
+    #    -h DIR          Home directory
+    #    -G GRP          Add user to existing group
+    #    -S              Create a system user
+    #    -D              Don't assign a password
+    #    -H              Don't create home directory
+    #    -u UID          User id
+    #    -k SKEL         Skeleton directory (/etc/skel)
+    userAddArgs="-D -S -H -u $UID"
 
-if [[ -n $UID ]]; then
-  useradd --home-dir=$BUNGEE_HOME --no-create-home $userAddArgs bungeecord
-  chown -R bungeecord: $BUNGEE_HOME
-  runuser -u bungeecord /usr/bin/java -- $JVM_OPTS -jar $BUNGEE_JAR "$@"
+    if [[ -n "$GID" ]]; then
+        userAddArgs="$userAddArgs -g $GID"
+        addgroup -g ${GID} bungeecord
+    fi
+
+    adduser -h ${BUNGEE_HOME} ${userAddArgs} bungeecord
+
+    chown -R bungeecord: ${BUNGEE_HOME}
+    sudo -u bungeecord java -- ${JVM_OPTS} -jar $BUNGEE_JAR "$@"
 else
-  exec java $JVM_OPTS -jar $BUNGEE_JAR "$@"
+    exec java $JVM_OPTS -jar $BUNGEE_JAR "$@"
 fi


### PR DESCRIPTION
The Alpine image has a much smaller footprint (and is a better choice IMHO) but does require a slightly different track with the initialization and user creation process.  After updating to the  e729d21 commit, the server could not complete initialization properly.  While this solution does somewhat hard code the UID and GID, it allows the server to fully come up and run as expected.