### PR TITLE
feat(volumes): copy configs from new /config volume on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u131-jre-alpine
 
-VOLUME ["/server", "/plugins"]
+VOLUME ["/server", "/plugins", "/config"]
 WORKDIR /server
 
 ENV BUNGEE_HOME=/server \

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ docker run ... -e ONLINE_MODE=FALSE itzg/minecraft-server
 
 * **/config**
   
-  Configs will be copied accros from this directory before the server is started.
-  Will **not** overwrite existing configs in the mounted `/server` volume.
+  The `/config/config.yml` file in this volume will be copied accross on startup if it is newer than the config in `/server/config.yml`.
 
 ## Ports
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ docker run ... -e ONLINE_MODE=FALSE itzg/minecraft-server
 
   Plugins will be copied across from this directory before the server is started.
 
+* **/config**
+  
+  Configs will be copied accros from this directory before the server is started.
+  Will **not** overwrite existing configs in the mounted `/server` volume.
+
 ## Ports
 
 * **25577**

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -17,7 +17,7 @@ fi
 
 if [ -d /config ]; then
     echo "Copying BungeeCord configs over..."
-    cp -n /config/* $BUNGEE_HOME
+    cp -u /config/config.yml "$BUNGEE_HOME/config.yml"
 fi
 
 if [ $UID == 0 ]; then

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -15,6 +15,11 @@ if [ -d /plugins ]; then
     cp -r /plugins $BUNGEE_HOME
 fi
 
+if [ -d /config ]; then
+    echo "Copying BungeeCord configs over..."
+    cp -n /config/* $BUNGEE_HOME
+fi
+
 if [ $UID == 0 ]; then
   chown -R bungeecord:bungeecord $BUNGEE_HOME
 fi


### PR DESCRIPTION
I added a new volume `/config` that can be used to initially copy configs at server start. A separate volume so configs controlled with git can be separated from the logs, and server dir.

The configs copied from the `/config` dir will not overwrite existing configs in the `/server` dir.

Should this be the case or should configs be overwritten? Maybe only of newer with the `-i` switch?