### PR TITLE
Allow replace environment variables in config files and fix BUNGEE_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ docker run ... -e ONLINE_MODE=FALSE itzg/minecraft-server
 * **JVM_OPTS**
 
   Additional -X options to pass to the JVM.
- 
+
 * **PLUGINS**
 
   Used to download a comma seperated list of *.jar urls to the plugins folder.
-  
+
   ```
   -e PLUGINS=https://www.example.com/plugin1.jar,https://www.example.com/plugin2.jar
   ```
-  
+
 ## Optional Environment Settings
 
 * **BUNGEE_JOB_ID**=lastStableBuild
@@ -51,7 +51,7 @@ docker run ... -e ONLINE_MODE=FALSE itzg/minecraft-server
 
   Defaults to the value of `${BUNGEE_JOB_ID}`, but can be set to an arbitrarily incremented value to force an upgrade of the downloaded BungeeCord jar file.
 
-* **BUNGEE_BASE_URL**=https://ci.md-5.net/job/BungeeCord
+* **BUNGEE_BASE_URL**=<https://ci.md-5.net/job/BungeeCord>
 
   Used to derive the default value of `BUNGEE_JAR_URL`
 
@@ -65,13 +65,13 @@ docker run ... -e ONLINE_MODE=FALSE itzg/minecraft-server
 
   The working directory where BungeeCord is started. This is the directory
   where its `config.yml` will be loaded.
-  
+
 * **/plugins**
 
   Plugins will be copied across from this directory before the server is started.
 
 * **/config**
-  
+
   The `/config/config.yml` file in this volume will be copied accross on startup if it is newer than the config in `/server/config.yml`.
 
 ## Ports
@@ -88,6 +88,76 @@ docker run ... -e ONLINE_MODE=FALSE itzg/minecraft-server
 ## BungeeCord Configuration
 
 [BungeeCord Configuration Guide](https://www.spigotmc.org/wiki/bungeecord-configuration-guide/)
+
+### Replacing variables inside configs
+
+Sometimes you have mods or plugins that require configuration information that is only available at runtime.
+For example if you need to configure a plugin to connect to a database,
+you don't want to include this information in your Git repository or Docker image.
+Or maybe you have some runtime information like the server name that needs to be set
+in your config files after the container starts.
+
+For those cases there is the option to replace defined variables inside your configs
+with environment variables defined at container runtime.
+
+If you set the enviroment variable `REPLACE_ENV_VARIABLES` to `TRUE` the startup script
+will go thru all files inside your `/server` volume and replace variables that match your
+defined environment variables. Variables that you want to replace need to be wrapped
+inside `${YOUR_VARIABLE}` curly brackets and prefixed with a dollar sign. This is the regular
+syntax for enviromment variables inside strings or config files.
+
+Optionally you can also define a prefix to only match predefined enviroment variables.
+
+`ENV_VARIABLE_PREFIX="CFG_"` <-- this is the default prefix
+
+There are some limitations to what characters you can use.
+
+| Type  | Allowed Characters  |
+| ----- | ------------------- |
+| Name  | `0-9a-zA-Z_-`       |
+| Value | `0-9a-zA-Z_-:/=?.+` |
+
+Variables will be replaced in files with the following extensions:
+`.yml`, `.yaml`, `.txt`, `.cfg`, `.conf`, `.properties`.
+
+Here is a full example where we want to replace values inside a `database.yml`.
+
+```yml
+
+---
+database:
+  host: ${CFG_DB_HOST}
+  name: ${CFG_DB_NAME}
+  password: ${CFG_DB_PASSWORD}
+```
+
+This is how your `docker-compose.yml` file could look like:
+
+```yml
+version: "3"
+# Other docker-compose examples in /examples
+
+services:
+  proxy:
+    image: itzg/bungeecord
+    ports:
+      - "25577:25577"
+    volumes:
+      - "proxy:/server"
+    environment:
+      # enable env variable replacement
+      REPLACE_ENV_VARIABLES: "TRUE"
+      # define an optional prefix for your env variables you want to replace
+      ENV_VARIABLE_PREFIX: "CFG_"
+      # and here are the actual variables
+      CFG_DB_HOST: "http://localhost:3306"
+      CFG_DB_NAME: "minecraft"
+      CFG_DB_PASSWORD: "ug23u3bg39o-ogADSs"
+    restart: always
+
+volumes:
+  proxy:
+```
 
 ## Scenarios
 

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -60,6 +60,24 @@ if [ -f /var/run/default-config.yml -a ! -f /server/config.yml ]; then
     fi
 fi
 
+# Replace environment variables in config files
+if [ "${REPLACE_ENV_VARIABLES^^}" = "TRUE" ]; then
+  echo "Replacing env variables in configs that match the prefix $ENV_VARIABLE_PREFIX..."
+  while IFS='=' read -r name value ; do
+    # check if name of env variable matches the prefix
+    # sanity check environment variables to avoid code injections
+    if [[ "$name" = $ENV_VARIABLE_PREFIX* ]] \
+        && [[ $value =~ ^[0-9a-zA-Z_:/=?.+\-]*$ ]] \
+        && [[ $name =~ ^[0-9a-zA-Z_\-]*$ ]]; then
+      echo "Replacing $name with $value ..."
+      find $BUNGEE_HOME -type f \
+          \( -name "*.yml" -or -name "*.yaml" -or -name "*.txt" -or -name "*.cfg" \
+          -or -name "*.conf" -or -name "*.properties" \) \
+          -exec sed -i 's#${'"$name"'}#'"$value"'#g' {} \;
+    fi
+  done < <(env)
+fi
+
 if [ $UID == 0 ]; then
   chown -R bungeecord:bungeecord $BUNGEE_HOME
 fi

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -96,7 +96,7 @@ fi
 
 if [ -f /var/run/default-config.yml -a ! -f $BUNGEE_HOME/config.yml ]; then
     echo "Installing default configuration"
-    cp /var/run/default-config.yml /config.yml
+    cp /var/run/default-config.yml $BUNGEE_HOME/config.yml
     if [ $UID == 0 ]; then
         chown bungeecord: $BUNGEE_HOME/config.yml
     fi

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-: ${BUNGEE_HOME:=/server}
 : ${BUNGEE_BASE_URL:=https://ci.md-5.net/job/BungeeCord}
 : ${MEMORY:=512m}
 : ${BUNGEE_JOB_ID:=lastStableBuild}
 : ${BUNGEE_JAR_URL:=${BUNGEE_BASE_URL}/${BUNGEE_JOB_ID}/artifact/bootstrap/target/BungeeCord.jar}
 : ${BUNGEE_JAR_REVISION:=${BUNGEE_JOB_ID}}
 
+BUNGEE_HOME=/server
 BUNGEE_JAR=$BUNGEE_HOME/BungeeCord-${BUNGEE_JAR_REVISION}.jar
 
 if [[ ! -e $BUNGEE_JAR ]]; then
@@ -36,8 +36,8 @@ do
         exit 2
       fi
 
-      mkdir -p /server/plugins
-      mv /tmp/${EFFECTIVE_PLUGIN_URL##*/} /server/plugins/${EFFECTIVE_PLUGIN_URL##*/}
+      mkdir -p $BUNGEE_HOME/plugins
+      mv /tmp/${EFFECTIVE_PLUGIN_URL##*/} "$BUNGEE_HOME/plugins/${EFFECTIVE_PLUGIN_URL##*/}"
       rm -f /tmp/${EFFECTIVE_PLUGIN_URL##*/}
       ;;
     *)
@@ -52,11 +52,11 @@ if [ -d /config ]; then
     cp -u /config/config.yml "$BUNGEE_HOME/config.yml"
 fi
 
-if [ -f /var/run/default-config.yml -a ! -f /server/config.yml ]; then
+if [ -f /var/run/default-config.yml -a ! -f $BUNGEE_HOME/config.yml ]; then
     echo "Installing default configuration"
-    cp /var/run/default-config.yml /server/config.yml
+    cp /var/run/default-config.yml /config.yml
     if [ $UID == 0 ]; then
-        chown bungeecord: /server/config.yml
+        chown bungeecord: $BUNGEE_HOME/config.yml
     fi
 fi
 


### PR DESCRIPTION
Hello,
This PR add possibility to replace environment variable if config like https://github.com/itzg/docker-minecraft-server#replacing-variables-inside-configs
This PR also remove possibility to modify `BUNGEE_HOME` for prevent misstake (and that environment variable is not documented).

Thanks.