### PR TITLE
Allow specifying a local JAR for the CUSTOM server type

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ healthy
   If set, can specify a custom, fully qualified URL  of the BungeeCord.jar; however, you won't be able reference the other environment variables from within a `docker run` a compose file. Defaults to:
 
   * (type: `BUNGEECORD`): `${BUNGEE_BASE_URL}/${BUNGEE_JOB_ID}/artifact/bootstrap/target/BungeeCord.jar`
+  
+  This takes precedence over `BUNGEE_JAR_FILE`.
+
+* **BUNGEE_JAR_FILE**
+
+  For `TYPE=CUSTOM`, allows setting a custom BungeeCord JAR that is located inside the container.
+  
+  Must be a valid path of an existing file.
 
 * **WATERFALL_VERSION**=latest
 

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -5,6 +5,7 @@
 : ${RCON_JAR_VERSION:=1.0.0}
 BUNGEE_HOME=/server
 RCON_JAR_URL=https://github.com/orblazer/bungee-rcon/releases/download/v${RCON_JAR_VERSION}/bungee-rcon-${RCON_JAR_VERSION}.jar
+download_required=true
 
 echo "Resolving type given ${TYPE}"
 case "${TYPE^^}" in
@@ -36,7 +37,6 @@ case "${TYPE^^}" in
     if [[ -v BUNGEE_JAR_URL ]]; then
       echo "Using custom server jar at ${BUNGEE_JAR_URL} ..."
       BUNGEE_JAR=$BUNGEE_HOME/$(basename ${BUNGEE_JAR_URL})
-      download_required=true
     elif [[ -v BUNGEE_JAR_FILE ]]; then
       BUNGEE_JAR=${BUNGEE_JAR_FILE}
       download_required=false

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -44,10 +44,10 @@ case "${TYPE^^}" in
 
   CUSTOM)
     if isURL ${BUNGEE_JAR_URL}; then
-      BUNGEE_JAR=$BUNGEE_HOME/$(basename ${BUNGEE_JAR_URL})
-    elif [[ -f ${BUNGEE_JAR_URL} ]]; then
       echo "Using custom server jar at ${BUNGEE_JAR_URL} ..."
       BUNGEE_JAR=${BUNGEE_JAR_URL}
+    elif [[ -f ${BUNGEE_JAR_URL} ]]; then
+      BUNGEE_JAR=$BUNGEE_HOME/$(basename ${BUNGEE_JAR_URL})
     else
       echo "BUNGEE_JAR_URL is not properly set to a URL or existing jar file"
       exit 2
@@ -61,14 +61,15 @@ case "${TYPE^^}" in
   ;;
 esac
 
-if [ -f "$BUNGEE_JAR" ]; then
-  zarg="-z '$BUNGEE_JAR'"
-fi
+BUNGEE_FILE_NAME=$BUNGEE_JAR
 
-echo "Downloading ${BUNGEE_JAR_URL}"
-if ! curl -o "$BUNGEE_JAR" -fsSL $zarg $BUNGEE_JAR_URL; then
-    echo "ERROR: failed to download" >&2
-    exit 2
+if ! [ -f "$BUNGEE_JAR" ]; then
+  BUNGEE_FILE_NAME=$(basename "$BUNGEE_JAR")
+  echo "Downloading ${BUNGEE_JAR_URL}"
+  if ! curl -o "$BUNGEE_FILE_NAME" -z "$BUNGEE_FILE_NAME" -fsSL $BUNGEE_JAR_URL; then
+      echo "ERROR: failed to download" >&2
+      exit 2
+  fi
 fi
 
 if [ -d /plugins ]; then
@@ -178,7 +179,7 @@ echo "Setting initial memory to ${INIT_MEMORY:-${MEMORY}} and max to ${MAX_MEMOR
 JVM_OPTS="-Xms${INIT_MEMORY:-${MEMORY}} -Xmx${MAX_MEMORY:-${MEMORY}} ${JVM_OPTS}"
 
 if [ $UID == 0 ]; then
-  exec sudo -E -u bungeecord java $JVM_OPTS -jar $BUNGEE_JAR "$@"
+  exec sudo -E -u bungeecord java $JVM_OPTS -jar $BUNGEE_FILE_NAME "$@"
 else
-  exec java $JVM_OPTS -jar $BUNGEE_JAR "$@"
+  exec java $JVM_OPTS -jar $BUNGEE_FILE_NAME "$@"
 fi


### PR DESCRIPTION
Currently, specifying a local file path to the `BUNGEE_JAR_URL` environment variable causes an error with cURL. This PR attempts to fix that by bypassing cURL when a file path is specified instead of a URL.

Tested scenarios:
- Downloading a JAR from `https://papermc.io/api/v1/waterfall/1.16/381/download` (The script places it into a file called `download` in the `/server/` folder)
- Using a JAR in `/server/server.jar`

Fixes #34 

I am new to writing bash scripts to let me know if you see anything that needs to be changed with this! As far as I know, this won't break existing servers upgrading to this version of the script.