### PR TITLE
Copy messages.properties file from config volume too

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ healthy
 
   The `/config/config.yml` file in this volume will be copied accross on startup if it is newer than the config in `/server/config.yml`.
 
-  If `server-icon.png`, `modules.yml` or `waterfall.yml` also exists in the volume, they will also be copied if newer.
+  If `server-icon.png`, `modules.yml`, `waterfall.yml` or `messages.properties` also exists in the volume, they will also be copied if newer.
 
 ## Ports
 

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -129,6 +129,10 @@ if [ -d /config ]; then
     if [ -f /config/waterfall.yml ]; then
       cp -u /config/waterfall.yml "$BUNGEE_HOME/waterfall.yml"
     fi
+    # Messages
+    if [ -f /config/messages.properties ]; then
+      cp -u /config/messages.properties "$BUNGEE_HOME/messages.properties"
+    fi
 fi
 
 if [ -f /var/run/default-config.yml -a ! -f $BUNGEE_HOME/config.yml ]; then


### PR DESCRIPTION
Hey! This should make the server copy `messages.properties` from the config volume as well.

Bungeecord messages can be tweaked through it. I'm not 100% sure if its a waterfall-only feature, but it does work here.

Thanks