### PR TITLE
Bump default Velocity version

### DIFF
--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -53,7 +53,7 @@ case "${TYPE^^}" in
   ;;
 
   VELOCITY)
-    : ${VELOCITY_VERSION:=1.1.0}
+    : ${VELOCITY_VERSION:=1.1.4}
     BUNGEE_JAR_URL="https://versions.velocitypowered.com/download/${VELOCITY_VERSION}.jar"
     BUNGEE_JAR=$BUNGEE_HOME/Velocity-${VELOCITY_VERSION}.jar
   ;;


### PR DESCRIPTION
Velocity 1.1.0 has been outdated since last October