### PR TITLE
Added support for RCON on Velocity servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ COPY health.sh /
 RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
  --var version=1.4.7 --var app=rcon-cli --file {{.app}} \
  --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
-COPY rcon-config.yml /tmp/rcon-config.yml
+COPY rcon-config.yml /templates/rcon-config.yml
+COPY rcon-velocity-config.toml /templates/rcon-velocity-config.toml 
 
 ENV SERVER_PORT=25577 RCON_PORT=25575
 EXPOSE $SERVER_PORT

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ healthy
 
 * **ENABLE_RCON**
 
-  Enable the rcon server (that uses a third-party plugin to work, [orblazer/bungee-rcon](https://github.com/orblazer/bungee-rcon), which is automatically downloaded)
+  Enable the rcon server (uses a third-party plugin to work).
+  - [orblazer/bungee-rcon](https://github.com/orblazer/bungee-rcon) for `BUNGEECORD`, `WATERFALL`, and `CUSTOM`
+  - [UnioDex/VelocityRcon](https://github.com/UnioDex/VelocityRcon) for `VELOCITY`
 
 * **RCON_PORT**
 

--- a/rcon-config.yml
+++ b/rcon-config.yml
@@ -1,6 +1,6 @@
 # Port you want RCON to listen
-port: "${PORT}"
+port: ${PORT}
 # Password you want to authenticate connection with
-password: "${PASSWORD}"
+password: ${PASSWORD}
 # This can be used if you want RCON response to be (not) colored
 colored: false

--- a/rcon-config.yml
+++ b/rcon-config.yml
@@ -1,6 +1,6 @@
 # Port you want RCON to listen
-port: ${PORT}
+port: "${PORT}"
 # Password you want to authenticate connection with
-password: ${PASSWORD}
+password: "${PASSWORD}"
 # This can be used if you want RCON response to be (not) colored
 colored: false

--- a/rcon-velocity-config.toml
+++ b/rcon-velocity-config.toml
@@ -1,0 +1,3 @@
+rcon-port = ${PORT}
+rcon-password = ${PASSWORD}
+rcon-colored = false

--- a/rcon-velocity-config.toml
+++ b/rcon-velocity-config.toml
@@ -1,3 +1,3 @@
-rcon-port = ${PORT}
-rcon-password = ${PASSWORD}
+rcon-port = "${PORT}"
+rcon-password = "${PASSWORD}"
 rcon-colored = false

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -168,11 +168,11 @@ if [ "${TYPE^^}" = "VELOCITY" ]; then # Download UnioDex/VelocityRcon plugin
     fi
 
     echo "Copy Velocity rcon configuration"
-    sed -i 's#${PORT}#'"$RCON_PORT"'#g' /tmp/rcon-velocity-config.toml
-    sed -i 's#${PASSWORD}#'"$RCON_PASSWORD"'#g' /tmp/rcon-velocity-config.toml
+    sed -i 's#${PORT}#'"$RCON_PORT"'#g' /templates/rcon-velocity-config.toml
+    sed -i 's#${PASSWORD}#'"$RCON_PASSWORD"'#g' /templates/rcon-velocity-config.toml
 
-    mv /tmp/rcon-velocity-config.toml "$BUNGEE_HOME/plugins/velocityrcon/rcon.toml"
-    rm -f /tmp/rcon-velocity-config.toml
+    mv /templates/rcon-velocity-config.toml "$BUNGEE_HOME/plugins/velocityrcon/rcon.toml"
+    rm -f /templates/rcon-velocity-config.toml
   fi
 else # Download orblazer/bungee-rcon plugin
   if isTrue "${ENABLE_RCON}" && [[ ! -e $BUNGEE_HOME/plugins/${RCON_JAR_URL##*/} ]]; then
@@ -185,11 +185,11 @@ else # Download orblazer/bungee-rcon plugin
     fi
 
     echo "Copy Bungee rcon configuration"
-    sed -i 's#${PORT}#'"$RCON_PORT"'#g' /tmp/rcon-config.yml
-    sed -i 's#${PASSWORD}#'"$RCON_PASSWORD"'#g' /tmp/rcon-config.yml
+    sed -i 's#${PORT}#'"$RCON_PORT"'#g' /templates/rcon-config.yml
+    sed -i 's#${PASSWORD}#'"$RCON_PASSWORD"'#g' /templates/rcon-config.yml
 
-    mv /tmp/rcon-config.yml "$BUNGEE_HOME/plugins/bungee-rcon/config.yml"
-    rm -f /tmp/rcon-config.yml
+    mv /templates/rcon-config.yml "$BUNGEE_HOME/plugins/bungee-rcon/config.yml"
+    rm -f /templates/rcon-config.yml
   fi
 fi
 

--- a/run-bungeecord.sh
+++ b/run-bungeecord.sh
@@ -3,9 +3,11 @@
 : ${TYPE:=BUNGEECORD}
 : ${MEMORY:=512m}
 : ${RCON_JAR_VERSION:=1.0.0}
+: ${RCON_VELOCITY_JAR_VERSION:=1.0}
 : ${ENV_VARIABLE_PREFIX:=CFG_}
 BUNGEE_HOME=/server
 RCON_JAR_URL=https://github.com/orblazer/bungee-rcon/releases/download/v${RCON_JAR_VERSION}/bungee-rcon-${RCON_JAR_VERSION}.jar
+RCON_VELOCITY_JAR_URL=https://github.com/UnioDex/VelocityRcon/releases/download/v${RCON_VELOCITY_JAR_VERSION}/VelocityRcon.jar
 download_required=true
 
 function isTrue() {
@@ -57,7 +59,7 @@ case "${TYPE^^}" in
     : ${WATERFALL_VERSION:=latest}
     : ${WATERFALL_BUILD_ID:=latest}
 
-    # Retrieve waterfal version
+    # Retrieve waterfall version
     if [[ ${WATERFALL_VERSION^^} = LATEST ]]; then
       WATERFALL_VERSION=$(curl -fsSL "https://papermc.io/api/v2/projects/waterfall" -H "accept: application/json" | jq -r '.versions[-1]')
       if [ -z $WATERFALL_VERSION ]; then
@@ -155,21 +157,40 @@ done
 fi
 
 # Download rcon plugin
-if isTrue "${ENABLE_RCON}" && [[ ! -e $BUNGEE_HOME/plugins/${RCON_JAR_URL##*/} ]]; then
-  echo "Downloading rcon plugin"
-  mkdir -p $BUNGEE_HOME/plugins/bungee-rcon
+if [ "${TYPE^^}" = "VELOCITY" ]; then # Download UnioDex/VelocityRcon plugin
+  if isTrue "${ENABLE_RCON}" && [[ ! -e $BUNGEE_HOME/plugins/${RCON_VELOCITY_JAR_URL##*/} ]]; then
+    echo "Downloading Velocity rcon plugin"
+    mkdir -p $BUNGEE_HOME/plugins/velocityrcon
 
-  if ! curl -sSL -o "$BUNGEE_HOME/plugins/${RCON_JAR_URL##*/}" $RCON_JAR_URL; then
-    echo "ERROR: failed to download from $RCON_JAR_URL to /tmp/${RCON_JAR_URL##*/}"
-    exit 2
+    if ! curl -sSL -o "$BUNGEE_HOME/plugins/${RCON_VELOCITY_JAR_URL##*/}" $RCON_VELOCITY_JAR_URL; then
+      echo "ERROR: failed to download from $RCON_VELOCITY_JAR_URL to /tmp/${RCON_VELOCITY_JAR_URL##*/}"
+      exit 2
+    fi
+
+    echo "Copy Velocity rcon configuration"
+    sed -i 's#${PORT}#'"$RCON_PORT"'#g' /tmp/rcon-velocity-config.toml
+    sed -i 's#${PASSWORD}#'"$RCON_PASSWORD"'#g' /tmp/rcon-velocity-config.toml
+
+    mv /tmp/rcon-velocity-config.toml "$BUNGEE_HOME/plugins/velocityrcon/rcon.toml"
+    rm -f /tmp/rcon-velocity-config.toml
   fi
+else # Download orblazer/bungee-rcon plugin
+  if isTrue "${ENABLE_RCON}" && [[ ! -e $BUNGEE_HOME/plugins/${RCON_JAR_URL##*/} ]]; then
+    echo "Downloading Bungee rcon plugin"
+    mkdir -p $BUNGEE_HOME/plugins/bungee-rcon
 
-  echo "Copy rcon configuration"
-  sed -i 's#${PORT}#'"$RCON_PORT"'#g' /tmp/rcon-config.yml
-  sed -i 's#${PASSWORD}#'"$RCON_PASSWORD"'#g' /tmp/rcon-config.yml
+    if ! curl -sSL -o "$BUNGEE_HOME/plugins/${RCON_JAR_URL##*/}" $RCON_JAR_URL; then
+      echo "ERROR: failed to download from $RCON_JAR_URL to /tmp/${RCON_JAR_URL##*/}"
+      exit 2
+    fi
 
-  mv /tmp/rcon-config.yml "$BUNGEE_HOME/plugins/bungee-rcon/config.yml"
-  rm -f /tmp/rcon-config.yml
+    echo "Copy Bungee rcon configuration"
+    sed -i 's#${PORT}#'"$RCON_PORT"'#g' /tmp/rcon-config.yml
+    sed -i 's#${PASSWORD}#'"$RCON_PASSWORD"'#g' /tmp/rcon-config.yml
+
+    mv /tmp/rcon-config.yml "$BUNGEE_HOME/plugins/bungee-rcon/config.yml"
+    rm -f /tmp/rcon-config.yml
+  fi
 fi
 
 if [ -d /config ]; then


### PR DESCRIPTION
BungeeCord plugins, such as [orblazer/bungee-rcon](https://github.com/orblazer/bungee-rcon), are not directly compatible with Velocity servers.  As a result, the RCON plugin fails to function on Velocity servers.

I suggest using another third-party plugin, [UnioDex/VelocityRcon](https://github.com/UnioDex/VelocityRcon), to bring RCON support for Velocity servers. I haven't found any problems using it in my tests and I also audited the source code for issues.