### PR TITLE
Update mc-image-helper, rcon-cli and mc-monitor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,18 +31,18 @@ RUN chmod +x /usr/bin/easy-add
 
 # Add mc-monitor
 RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
- --var version=0.8.0 --var app=mc-monitor --file {{.app}} \
+ --var version=0.10.6 --var app=mc-monitor --file {{.app}} \
  --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 COPY health.sh /
 
 # Add rcon-cli
 RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
- --var version=1.4.7 --var app=rcon-cli --file {{.app}} \
+ --var version=1.5.1 --var app=rcon-cli --file {{.app}} \
  --from https://github.com/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 COPY rcon-config.yml /templates/rcon-config.yml
 COPY rcon-velocity-config.toml /templates/rcon-velocity-config.toml 
 
-ARG MC_HELPER_VERSION=1.9.13
+ARG MC_HELPER_VERSION=1.16.6
 ARG MC_HELPER_BASE_URL=https://github.com/itzg/mc-image-helper/releases/download/v${MC_HELPER_VERSION}
 RUN curl -fsSL ${MC_HELPER_BASE_URL}/mc-image-helper-${MC_HELPER_VERSION}.tgz \
     | tar -C /usr/share -zxf - \


### PR DESCRIPTION
Update software:
- **mc-monitor** from 0.8.0 to 0.10.6
- **rcon-cli from** 1.4.7 to 1.5.1
- **mc-image-helper** from 1.9.13 to 1.16.6

Tested:
- My server: https://github.com/bensuperpc/docker-minecraft-server
- RconWeb

Signed-off-by: Bensuperpc <bensuperpc@gmail.com>