### PR TITLE
Make `REMOVE_OLD_PLUGINS` independent from `SPIGET_RESOURCES`

### DIFF
--- a/scripts/run-bungeecord.sh
+++ b/scripts/run-bungeecord.sh
@@ -375,12 +375,18 @@ if [[ "$PLUGINS" ]]; then
           "$PLUGINS"
 fi
 
-if [[ ${SPIGET_PLUGINS} ]]; then
-  if isTrue "${REMOVE_OLD_PLUGINS:-false}"; then
-    removeOldMods $BUNGEE_HOME/plugins
-    REMOVE_OLD_PLUGINS=false
-  fi
+# Remove old plugins as long as REMOVE_OLD_PLUGINS or REMOVE_OLD_MODS is set to true
+# REMOVE_OLD_MODS is available to be consistent with the docker-minecraft-server image
+# Note that only REMOVE_OLD_MODS_EXCLUDE and REMOVE_OLD_MODS_INCLUDE are supported.
+if isTrue "${REMOVE_OLD_PLUGINS:-false}" || isTrue "${REMOVE_OLD_MODS:-false}"; then
+  log "Removing old plugins including:${REMOVE_OLD_MODS_INCLUDE} excluding:${REMOVE_OLD_MODS_EXCLUDE}"
+  removeOldMods $BUNGEE_HOME/plugins
+  REMOVE_OLD_PLUGINS=false
+  REMOVE_OLD_MODS=false
+fi
 
+# Download plugins from spigotmc and put them in the plugins folder
+if [[ ${SPIGET_PLUGINS} ]]; then
   log "Getting plugins via Spiget"
   IFS=',' read -r -a resources <<<"${SPIGET_PLUGINS}"
   for resource in "${resources[@]}"; do


### PR DESCRIPTION
This makes the behavior consistent with docker-minecraft-server since `removeOldMods` is called once in 
https://github.com/itzg/docker-minecraft-server/blob/f659c56f184a8167a2d6c83e68d4065a093d3b73/scripts/start-spiget#L131 if `SPIGET_RESOURCES` is used and then it is called again in 
https://github.com/itzg/docker-minecraft-server/blob/f659c56f184a8167a2d6c83e68d4065a093d3b73/scripts/start-setupModpack#L26 regardless of `SPIGET_RESOURCES`.

I think this is expected behavior and I used this to remove old jar files which were supplied via the `/plugins` mount without using `SPIGET_RESOURCES`.