### PR TITLE
fix: remove plugins before copying from /plugins

### DIFF
--- a/scripts/run-bungeecord.sh
+++ b/scripts/run-bungeecord.sh
@@ -360,6 +360,16 @@ if [[ $pruningPrefix ]]; then
   pruneOlder "$pruningPrefix"
 fi
 
+# Remove old plugins as long as REMOVE_OLD_PLUGINS or REMOVE_OLD_MODS is set to true
+# REMOVE_OLD_MODS is available to be consistent with the docker-minecraft-server image
+# Note that only REMOVE_OLD_MODS_EXCLUDE and REMOVE_OLD_MODS_INCLUDE are supported.
+if isTrue "${REMOVE_OLD_PLUGINS:-false}" || isTrue "${REMOVE_OLD_MODS:-false}"; then
+  log "Removing old plugins including:${REMOVE_OLD_MODS_INCLUDE} excluding:${REMOVE_OLD_MODS_EXCLUDE}"
+  removeOldMods $BUNGEE_HOME/plugins
+  REMOVE_OLD_PLUGINS=false
+  REMOVE_OLD_MODS=false
+fi
+
 if [ -d /plugins ]; then
     log "Copying BungeeCord plugins over..."
     cp -ru /plugins $BUNGEE_HOME
@@ -373,16 +383,6 @@ if [[ "$PLUGINS" ]]; then
           --scope=var-list \
           --to="$BUNGEE_HOME/plugins" \
           "$PLUGINS"
-fi
-
-# Remove old plugins as long as REMOVE_OLD_PLUGINS or REMOVE_OLD_MODS is set to true
-# REMOVE_OLD_MODS is available to be consistent with the docker-minecraft-server image
-# Note that only REMOVE_OLD_MODS_EXCLUDE and REMOVE_OLD_MODS_INCLUDE are supported.
-if isTrue "${REMOVE_OLD_PLUGINS:-false}" || isTrue "${REMOVE_OLD_MODS:-false}"; then
-  log "Removing old plugins including:${REMOVE_OLD_MODS_INCLUDE} excluding:${REMOVE_OLD_MODS_EXCLUDE}"
-  removeOldMods $BUNGEE_HOME/plugins
-  REMOVE_OLD_PLUGINS=false
-  REMOVE_OLD_MODS=false
 fi
 
 # Download plugins from spigotmc and put them in the plugins folder


### PR DESCRIPTION
Follow up to #177

I made an error and currently plugins that match the provided patterns are removed after new ones are copied from `/plugins`  or downloaded. Now old plugins are removed BEFORE new ones are downloaded. 