### PR TITLE
Update library versions to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,23 +28,23 @@ ARG TARGETVARIANT
 ARG APPS_REV=1
 ARG GITHUB_BASEURL=https://github.com
 
-ARG EASY_ADD_VERSION=0.8.2
+ARG EASY_ADD_VERSION=0.8.6
 ADD ${GITHUB_BASEURL}/itzg/easy-add/releases/download/${EASY_ADD_VERSION}/easy-add_${TARGETOS}_${TARGETARCH}${TARGETVARIANT} /usr/bin/easy-add
 RUN chmod +x /usr/bin/easy-add
 
-ARG MC_MONITOR_VERSION=0.12.8
+ARG MC_MONITOR_VERSION=0.12.12
 RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${MC_MONITOR_VERSION} --var app=mc-monitor --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
-ARG RCON_CLI_VERSION=1.6.4
+ARG RCON_CLI_VERSION=1.6.7
 RUN easy-add --var os=${TARGETOS} --var arch=${TARGETARCH}${TARGETVARIANT} \
   --var version=${RCON_CLI_VERSION} --var app=rcon-cli --file {{.app}} \
   --from ${GITHUB_BASEURL}/itzg/{{.app}}/releases/download/{{.version}}/{{.app}}_{{.version}}_{{.os}}_{{.arch}}.tar.gz
 
 COPY --chmod=444 templates/ /templates/
 
-ARG MC_HELPER_VERSION=1.37.0
+ARG MC_HELPER_VERSION=1.39.0
 ARG MC_HELPER_BASE_URL=${GITHUB_BASEURL}/itzg/mc-image-helper/releases/download/${MC_HELPER_VERSION}
 # used for cache busting local copy of mc-image-helper
 ARG MC_HELPER_REV=1


### PR DESCRIPTION
Updated itzg libraries to latest versions available

RCON CLI 1.6.4 => 1.6.7

MC HELPER 1.37.0 =>1.39.0

EASY ADD 0.8.2 => 0.8.6

MC MONITOR 0.12.8 => 0.12.12