### PR TITLE
Switch Velocity Rcon plugin to TribufuFork

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ healthy
 
   Enable the rcon server (uses a third-party plugin to work).
   - [orblazer/bungee-rcon](https://github.com/orblazer/bungee-rcon) for `BUNGEECORD`, `WATERFALL`, and `CUSTOM`
-  - [UnioDex/VelocityRcon](https://github.com/UnioDex/VelocityRcon) for `VELOCITY`
+  - [TribuFuForks/VelocityRcon](https://github.com/TribufuForks/VelocityRcon) for `VELOCITY`
 
 * **RCON_PORT**
 

--- a/scripts/run-bungeecord.sh
+++ b/scripts/run-bungeecord.sh
@@ -3,7 +3,7 @@
 : "${TYPE:=BUNGEECORD}"
 : "${DEBUG:=false}"
 : "${RCON_JAR_VERSION:=1.0.0}"
-: "${RCON_VELOCITY_JAR_VERSION:=1.1}"
+: "${RCON_VELOCITY_JAR_VERSION:=1.2.0}"
 : "${SPIGET_PLUGINS:=}"
 : "${NETWORKADDRESS_CACHE_TTL:=60}"
 : "${INIT_MEMORY:=${MEMORY}}"
@@ -24,7 +24,7 @@
 
 BUNGEE_HOME=/server
 RCON_JAR_URL=https://github.com/orblazer/bungee-rcon/releases/download/v${RCON_JAR_VERSION}/bungee-rcon-${RCON_JAR_VERSION}.jar
-RCON_VELOCITY_JAR_URL=https://github.com/UnioDex/VelocityRcon/releases/download/v${RCON_VELOCITY_JAR_VERSION}/VelocityRcon.jar
+RCON_VELOCITY_JAR_URL=https://mvn.tribufu.com/releases/com/tribufu/Tribufu-VelocityRcon/${RCON_VELOCITY_JAR_VERSION}/Tribufu-VelocityRcon-${RCON_VELOCITY_JAR_VERSION}.jar
 download_required=true
 
 set -eo pipefail


### PR DESCRIPTION
The Velocity rcon plugin from UnioDex (now ygtdmn) does not work properly, see this [issue](https://github.com/ygtdmn/VelocityRcon/issues/6).

There is a working version [published by Tribufu](https://github.com/TribufuForks/VelocityRcon) which fixes the issue, this PR switches the installed plugin to that one, along with the reference in the README.